### PR TITLE
Provide necessary documentation details to .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,11 @@ script:
     - cargo test --verbose
     - cargo doc --verbose
 
+after_success: |
+  [ $TRAVIS_BRANCH = master ] &&
+  [ $TRAVIS_PULL_REQUEST = false ] &&
+  cargo doc &&
+  echo "<meta http-equiv=refresh content=0;url=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`/index.html>" > target/doc/index.html &&
+  sudo pip install ghp-import &&
+  ghp-import -n target/doc &&
+  git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages


### PR DESCRIPTION
This should be the necessary `after_success` script to push the documentation of successful builds to Github Pages. The `cargo doc &&` line may be unnecessary since it's part of the above script.

You will still need to give Travis permissions following [this](http://hoverbear.org/2015/03/07/rust-travis-github-pages/#givingtravispermissions) bit.
