### PR TITLE
Do not use unstable language features any more

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -155,7 +155,7 @@ impl Element {
     /// tons of ways to set the `Position`.
     #[inline]
     pub fn container(self, w: i32, h: i32, pos: Position) -> Element {
-        new_element(w, h, Prim::Container(pos, box self))
+        new_element(w, h, Prim::Container(pos, Box::new(self)))
     }
 
     /// Stack elements vertically. To put `a` above `b` you would say: `a.above(b)`
@@ -453,7 +453,7 @@ pub fn draw_element<'a, C: CharacterCache, G: Graphics<Texture=C::Texture>>(
             }
         },
 
-        Prim::Container(position, box element) => {
+        Prim::Container(position, element) => {
             let Position { horizontal, vertical, x, y } = position;
             let Transform2D(matrix) = match (x, y) {
                 (Pos::Relative(x), Pos::Relative(y)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 //! Ported to Rust by Mitchell Nordine.
 //!
 
-#![feature(box_patterns, box_syntax, core)]
-
 extern crate color as color_lib;
 extern crate graphics;
 extern crate num;
@@ -26,4 +24,3 @@ pub mod form;
 pub mod text;
 pub mod transform_2d;
 pub mod utils;
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,9 +3,9 @@
 //!
 
 use std::f64::consts::PI;
-use num::Float;
+use num::{ Float, NumCast };
 use num::PrimInt as Int;
-use std::num::{cast, NumCast};
+use num::traits::cast;
 
 /// Convert turns to radians.
 pub fn turns<F: Float + NumCast>(t: F) -> F {


### PR DESCRIPTION
Generic numeric casts can be obtained from the num crate. Box syntax can also be avoided with slightly more verbose syntax.

Fixes #8.
