### PR TITLE
Add a cleared element

### DIFF
--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -41,7 +41,6 @@ fn main() {
         match event {
             Event::Render(args) => {
                 g2d.draw(&mut renderer, &output, args.viewport(), |_, graphics| {
-                    graphics::clear([0.0, 0.0, 0.0, 0.5], graphics);
                     let (w, h) = (args.width as f64, args.height as f64);
 
                     let mut renderer = Renderer::new(w, h, graphics).character_cache(&mut glyph_cache);
@@ -50,7 +49,9 @@ fn main() {
                     let form = elmesque_demo_form(secs);
 
                     // Convert the form to an `Element` for rendering.
-                    elmesque::form::collage(w as i32, h as i32, vec![form]).draw(&mut renderer);
+                    elmesque::form::collage(w as i32, h as i32, vec![form])
+                        .clear(elmesque::color::rgba(0.0, 0.0, 0.0, 0.5))
+                        .draw(&mut renderer);
 
 
                 });

--- a/src/element.rs
+++ b/src/element.rs
@@ -158,6 +158,14 @@ impl Element {
         new_element(w, h, Prim::Container(pos, Box::new(self)))
     }
 
+    /// Put an element in a cleared wrapper. The color provided will be the color that clears the
+    /// screen before rendering the contained element.
+    #[inline]
+    pub fn clear(self, color: Color) -> Element {
+        new_element(self.get_width(), self.get_height(),
+            Prim::Cleared(color, Box::new(self)))
+    }
+
     /// Stack elements vertically. To put `a` above `b` you would say: `a.above(b)`
     #[inline]
     pub fn above(self, other: Element) -> Element {
@@ -258,6 +266,7 @@ pub enum Prim {
     Container(Position, Box<Element>),
     Flow(Direction, Vec<Element>),
     Collage(i32, i32, Vec<Form>),
+    Cleared(Color, Box<Element>),
     Spacer,
 }
 
@@ -532,6 +541,11 @@ pub fn draw_element<'a, C: CharacterCache, G: Graphics<Texture=C::Texture>>(
                 let form = form.alpha(original_alpha * props.opacity);
                 form::draw_form(form, matrix, backend, maybe_character_cache, draw_state);
             }
+        },
+
+        Prim::Cleared(color, element) => {
+            backend.clear_color(color.to_fsa());
+            draw_element(*element, matrix, backend, maybe_character_cache, draw_state);
         },
 
         Prim::Spacer => {},


### PR DESCRIPTION
This new element clears the screen with a given color, before the element contained within is rendered.

This PR resolves #7. It's a draft for how clearing the screen can be described in a purely declarative way.
