### PR TITLE
Text position

### DIFF
--- a/src/form.rs
+++ b/src/form.rs
@@ -477,6 +477,7 @@ pub fn draw_form<'a, C: CharacterCache, G: Graphics<Texture=C::Texture>>(
             let Transform2D(matrix) = Transform2D(matrix).multiply(::transform_2d::scale_y(-1.0));
             if let Some(ref mut character_cache) = *maybe_character_cache {
                 use text::Style as TextStyle;
+                use text::Position as TextPosition;
                 use text::TextUnit;
                 let (total_width, max_height) = text.sequence.iter().fold((0.0, 0.0), |(w, h), unit| {
                     let TextUnit { ref string, ref style } = *unit;
@@ -486,7 +487,11 @@ pub fn draw_form<'a, C: CharacterCache, G: Graphics<Texture=C::Texture>>(
                     let new_max_height = if height > h { height } else { h };
                     (new_total_width, new_max_height)
                 });
-                let x_offset = -(total_width / 2.0).floor();
+                let x_offset = match text.position {
+                        TextPosition::Center  => -(total_width / 2.0).floor(),
+                        TextPosition::ToLeft  => -total_width.floor(),
+                        TextPosition::ToRight => 0.0
+                    };
                 let y_offset = (max_height / 3.0).floor(); // TODO: FIX THIS (3.0)
                 let Transform2D(matrix) = Transform2D(matrix)
                     .multiply(transform_2d::translation(x_offset, y_offset));

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 #[derive(Clone, Debug)]
 pub struct Text {
     pub sequence: Vec<TextUnit>,
+    pub position: Position,
 }
 
 
@@ -22,6 +23,14 @@ pub enum Line {
     Under,
     Over,
     Through,
+}
+
+/// Text position relative to center point
+#[derive(Copy, Clone, Debug)]
+pub enum Position {
+    Center,
+    ToLeft,
+    ToRight
 }
 
 
@@ -70,7 +79,8 @@ impl Text {
     /// Convert a string into text which can be styled and displayed.
     pub fn from_string(string: String) -> Text {
         Text {
-            sequence: vec![TextUnit { string: string, style: Style::default(), }]
+            sequence: vec![TextUnit { string: string, style: Style::default(), }],
+            position: Position::Center
         }
     }
 
@@ -88,10 +98,12 @@ impl Text {
 
     /// Put many chunks of text together.
     pub fn concat(texts: Vec<Text>) -> Text {
+        let position = texts.get(0).map(|t| t.position).unwrap_or(Position::Center);
         Text {
             sequence: texts.into_iter()
-                .flat_map(|Text { sequence }| sequence.into_iter())
-                .collect()
+                .flat_map(|Text { sequence, position }| sequence.into_iter())
+                .collect(),
+            position: position
         }
     }
 
@@ -114,6 +126,7 @@ impl Text {
         }).collect()).unwrap();
         Text {
             sequence: vec![TextUnit { string: string, style: style }],
+            ..self
         }
     }
 
@@ -183,5 +196,11 @@ impl Text {
         self
     }
 
+    /// Change the text position relative to it's center point
+    #[inline]
+    pub fn position(mut self, position: Position) -> Text {
+        self.position = position;
+        self
+    }
 }
 


### PR DESCRIPTION
This change allows the user to specify horizontal position of the text relative to the form's position (center, to the right, to the left). The default is "center", preserving original behavior.

A couple points to consider.

First, I'm not sure that the names are clear enough, maybe "Position" term is too broad and can be confused with the form's position. So maybe it should be renamed I just don't know to what.

Second, the text width is calculated in the ToRight case, although it's not needed. This can be optimized by splitting height and width calculation into two folds.
