### PR TITLE
Move to crates.io dependencies only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,45 +9,15 @@ license = "MIT"
 repository = "https://github.com/mitchmindtree/elmesque.git"
 homepage = "https://github.com/mitchmindtree/elmesque"
 
-
-
-[dev-dependencies.pistoncore-glutin_window]
-git = "https://github.com/PistonDevelopers/glutin_window.git"
-version = "*"
-
-[dev-dependencies.piston]
-git = "https://github.com/PistonDevelopers/piston.git"
-version = "*"
-
-[dev-dependencies.shader_version]
-git = "https://github.com/PistonDevelopers/shader_version"
-#version = "*"
-
-[dev-dependencies.gfx]
-git = "https://github.com/gfx-rs/gfx-rs"
-
-[dev-dependencies.piston-gfx_texture]
-git = "https://github.com/PistonDevelopers/gfx_texture.git"
-version = "*"
-
-[dev-dependencies.gfx_device_gl]
-git = "https://github.com/gfx-rs/gfx_device_gl.git"
-version = "*"
-
-[dev-dependencies.piston2d-gfx_graphics]
-git = "https://github.com/PistonDevelopers/gfx_graphics.git"
-version = "*"
-
-[dev-dependencies.piston_window]
-git = "https://github.com/PistonDevelopers/piston_window.git"
-version = "*"
-
-
-[dependencies.piston2d-graphics]
-git = "https://github.com/PistonDevelopers/graphics.git"
-
 [dependencies]
-num = "*"
-rand = "*"
-rustc-serialize = "*"
-vecmath = "*"
+num = "0.1"
+rand = "0.3"
+rustc-serialize = "0.3"
+vecmath = "0.0.23"
+piston2d-graphics = "0.0.47"
+
+[dev-dependencies]
+piston = "0.1.3"
+pistoncore-glutin_window = "0.0.8"
+shader_version = "0.0.6"
+piston2d-glium_graphics = "0.0.14"


### PR DESCRIPTION
This should make #20 possible. The piston_window + gfx backend was switched for
a glutin/glium backend in the example, since they are using only crates.io dependencies.
