### PR TITLE
Use latest crates.io deps, increment version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elmesque"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "An attempt at porting Elm's incredibly useful, purely functional std graphics modules."
 readme = "README.md"
@@ -18,12 +18,12 @@ rustc-serialize = "*"
 vecmath = "*"
 
 [dev-dependencies]
-gfx = "0.6.0"
-gfx_device_gl = "0.4.0"
+gfx = "0.6.*"
+gfx_device_gl = "0.4.*"
 piston = "0.1.3"
-piston-gfx_texture = "0.0.7"
-piston_window = "0.0.8"
-piston2d-gfx_graphics = "0.1.21"
-pistoncore-glutin_window= "0.0.9"
-shader_version = "0.0.6"
+piston-gfx_texture = "0.1.0"
+piston_window = "0.1.0"
+piston2d-gfx_graphics = "0.1.22"
+pistoncore-glutin_window= "0.1.0"
+shader_version = "0.1.0"
 


### PR DESCRIPTION
All the piston lib versions recently increased to a minimum of 0.1.0 - adapting to the change.

elmesque is now at 0.1.1
