### PR TITLE
Use (more complex) GlutinWindow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,8 @@ rustc-serialize = "*"
 vecmath = "0.1.1"
 
 [dev-dependencies]
-find_folder = "0.1.1"
-gfx = "0.6.*"
-gfx_device_gl = "0.4.*"
 piston = "0.2.2"
-piston-gfx_texture = "0.2.0"
-piston_window = "0.6.2"
+piston2d-opengl_graphics = "0.3.0"
 piston2d-gfx_graphics = "0.3.1"
 pistoncore-glutin_window= "0.3.0"
-shader_version = "0.1.0"
 


### PR DESCRIPTION
This is what one usually sees these days when piston is involved.
However, it makes the event loop more complex, even though the
instantiation of the opengl `GlyphCache` is neater now.

It seems like a +-0 commit, which gains some, and looses some.

**I post this PR just for completeness, please feel free to close it unmerged**.
